### PR TITLE
Docker / docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 
 # Config #
 context-gpconnect.xml
+config/gpconnect-demonstrator-api.environment.properties

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8-jdk
+
+ENV NODE_VERSION 6.10.2
+
+RUN mkdir -p /usr/src/app && \
+    apt-get update -y && \
+    apt-get install maven -y && \
+    curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
+    tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
+    rm "node-v$NODE_VERSION-linux-x64.tar.xz" && \
+    npm install -g grunt-cli bower
+
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+
+RUN cd /usr/src/app/webapp && \
+    bower install --allow-root && \
+    bower update --allow-root && \
+    npm update && \
+    cd /usr/src/app && \
+    mvn clean package

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# By putting the create_database.sql script in this directory the mysql Docker image will run it on startup
+mkdir -p docker-entrypoint-initdb.d
+cp config/sql/create_database.sql docker-entrypoint-initdb.d/create_database.sql
+
+# The only property we need to override is the MySQL host
+echo "legacy.datasource.host = mysql" > config/gpconnect-demonstrator-api.environment.properties
+
+# Build all the containers
+docker-compose -f docker/docker-compose.yaml build
+
+# Need to start up the MySQL container so that the database gets created
+docker-compose -f docker/docker-compose.yaml up -d mysql
+
+# We don't need this anymore
+rm -r docker-entrypoint-initdb.d
+
+echo "Build successful"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '2'
+services:
+  gpconnect:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    links:
+      - mysql
+    ports:
+      - "19191:19191"
+    command: java -jar gpconnect-demonstrator-api/target/gpconnect-demonstrator-api.war --server.port=19191 --config.path=config/
+  webapp:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    links:
+      - gpconnect
+    environment:
+      - GP_CONNECT_WEBAPP_HOSTNAME=0.0.0.0
+      - GP_CONNECT_API_HOSTNAME=gpconnect
+    ports:
+      - "9000:9000"
+    working_dir: /usr/src/app/webapp
+    command: grunt serve
+  mysql:
+    image: mysql/mysql-server
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=answer
+      - MYSQL_PASSWORD=answer99q
+      - MYSQL_DATABASE=gpconnect
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+set -e
+
+docker-compose -f docker/docker-compose.yaml up

--- a/webapp/Gruntfile.js
+++ b/webapp/Gruntfile.js
@@ -73,20 +73,20 @@ module.exports = function(grunt) {
             options: {
                 port: 9000,
                 // Change this to '0.0.0.0' to access the server from outside.
-                hostname: 'localhost',
+                hostname: process.env.GP_CONNECT_WEBAPP_HOSTNAME || 'localhost',
                 livereload: 35729
             },
             proxies: [
                 {
                     context: '/api',
-                    host: 'localhost',
+                    host: process.env.GP_CONNECT_API_HOSTNAME || 'localhost',
                     port: 19191,
                     https: false,
                     xforward: false
                 },
                 {
                     context: '/fhir',
-                    host: 'localhost',
+                    host: process.env.GP_CONNECT_API_HOSTNAME || 'localhost',
                     port: 19191,
                     https: false,
                     xforward: false


### PR DESCRIPTION
Hey,

Wanted to get this project running locally as prep for integrating with GP Connect and though it might be useful to add a docker setup. Similar to #11 (which uses Vagrant) this adds support for running the project using Docker and Docker Compose.

Tested on Mac OSX using Docker for Mac but should also work on Linux environments. You just need docker and docker-compose installed.

Scripts:
* `./docker/build.sh` - builds all the containers and starts the mysql service
* `./docker/run.sh` - runs the app

The app then runs on `http://localhost:9000`.

Any feedback welcome.